### PR TITLE
test: add coverage for untested components and utilities

### DIFF
--- a/components/BackToTop/BackToTop.test.tsx
+++ b/components/BackToTop/BackToTop.test.tsx
@@ -1,0 +1,37 @@
+import BackToTop from '@/components/BackToTop/BackToTop'
+import {render, screen} from '@/test-utils'
+import userEvent from '@testing-library/user-event'
+
+const {scrollRef, scrollToMock} = vi.hoisted(() => ({
+  scrollRef: {y: 0},
+  scrollToMock: vi.fn()
+}))
+
+vi.mock('@mantine/hooks', () => ({
+  useWindowScroll: () => [scrollRef, scrollToMock]
+}))
+
+describe('BackToTop', () => {
+  beforeEach(() => {
+    scrollRef.y = 0
+    scrollToMock.mockClear()
+  })
+
+  it('does not render when scrolled less than or equal to 200', () => {
+    scrollRef.y = 100
+    render(<BackToTop />)
+    expect(
+      screen.queryByRole('button', {name: 'Go back to the top of the page'})
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders button and scrolls to top when clicked', async () => {
+    scrollRef.y = 250
+    render(<BackToTop />)
+    const button = screen.getByRole('button', {
+      name: 'Go back to the top of the page'
+    })
+    await userEvent.click(button)
+    expect(scrollToMock).toHaveBeenCalledWith({y: 0})
+  })
+})

--- a/components/BossButton/BossButton.test.tsx
+++ b/components/BossButton/BossButton.test.tsx
@@ -1,0 +1,39 @@
+import BossButton from '@/components/BossButton/BossButton'
+import {render, screen} from '@/test-utils'
+
+const {useBossButtonMock} = vi.hoisted(() => ({
+  useBossButtonMock: vi.fn()
+}))
+
+vi.mock('@/lib/hooks/useBossButton', () => ({
+  useBossButton: useBossButtonMock
+}))
+
+describe('BossButton', () => {
+  beforeEach(() => {
+    useBossButtonMock.mockReset()
+  })
+
+  it('does not render when shouldShow is false', () => {
+    useBossButtonMock.mockReturnValue({
+      shouldShow: false,
+      redirectUrl: 'https://example.com',
+      buttonText: 'Boss Button'
+    })
+    render(<BossButton />)
+    expect(
+      screen.queryByRole('link', {name: /Boss Button/})
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders link to redirectUrl when shouldShow is true', () => {
+    useBossButtonMock.mockReturnValue({
+      shouldShow: true,
+      redirectUrl: 'https://example.com',
+      buttonText: 'Boss Button'
+    })
+    render(<BossButton />)
+    const link = screen.getByRole('link', {name: /Boss Button/})
+    expect(link).toHaveAttribute('href', 'https://example.com')
+  })
+})

--- a/lib/utils/storage.test.ts
+++ b/lib/utils/storage.test.ts
@@ -1,0 +1,44 @@
+import {
+  getInitialSettings,
+  loadSettings,
+  saveSettings,
+  clearSettings
+} from './storage'
+
+describe('storage utilities', () => {
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('getInitialSettings returns defaults', () => {
+    expect(getInitialSettings()).toEqual({
+      currentSort: 'hot',
+      currentSubreddit: '',
+      enableNsfw: true,
+      favorites: [],
+      isMuted: true,
+      recent: []
+    })
+  })
+
+  it('loadSettings returns defaults when nothing stored', () => {
+    expect(loadSettings()).toEqual(getInitialSettings())
+  })
+
+  it('saveSettings persists settings and loadSettings retrieves them', () => {
+    const settings = {
+      ...getInitialSettings(),
+      currentSubreddit: 'reactjs',
+      isMuted: false
+    }
+    saveSettings(settings)
+    expect(loadSettings()).toEqual(settings)
+  })
+
+  it('clearSettings removes saved settings', () => {
+    const settings = {...getInitialSettings(), currentSubreddit: 'reactjs'}
+    saveSettings(settings)
+    clearSettings()
+    expect(loadSettings()).toEqual(getInitialSettings())
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for BackToTop conditional rendering and scroll behavior
- cover BossButton visibility and link target
- exercise storage utility defaults, persistence, and clearing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc88202dd483208704e4adbc0a253e