### PR TITLE
test: add missing component tests

### DIFF
--- a/components/Favorite/Favorite.test.tsx
+++ b/components/Favorite/Favorite.test.tsx
@@ -1,0 +1,30 @@
+import {Favorite} from '@/components/Favorite/Favorite'
+import {render, screen} from '@/test-utils'
+import userEvent from '@testing-library/user-event'
+
+const toggleMock = vi.fn()
+vi.mock('@/lib/hooks/useToggleFavorite', () => ({
+  useToggleFavorite: () => ({
+    isFavorite: false,
+    loading: false,
+    toggle: toggleMock
+  })
+}))
+
+describe('Favorite', () => {
+  beforeEach(() => {
+    toggleMock.mockClear()
+  })
+
+  it('does not render for disallowed subreddits', () => {
+    render(<Favorite subreddit="all" />)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('renders button and toggles favorite on click', async () => {
+    render(<Favorite subreddit="nextjs" />)
+    const btn = screen.getByRole('button', {name: 'Add to favorites'})
+    await userEvent.click(btn)
+    expect(toggleMock).toHaveBeenCalled()
+  })
+})

--- a/components/HlsPlayer/HlsPlayer.test.tsx
+++ b/components/HlsPlayer/HlsPlayer.test.tsx
@@ -1,0 +1,26 @@
+import {HlsPlayer} from '@/components/HlsPlayer/HlsPlayer'
+import {render} from '@/test-utils'
+
+const videoRef = {current: null}
+vi.mock('@/lib/hooks/useHlsVideo', () => ({
+  useHlsVideo: () => ({videoRef, isLoading: false, isMuted: false})
+}))
+
+describe('HlsPlayer', () => {
+  it('renders video element', () => {
+    render(
+      <HlsPlayer
+        src="video.m3u8"
+        fallbackUrl="fallback.mp4"
+        poster="poster.jpg"
+        id="123"
+        dataHint="video"
+      />
+    )
+
+    expect(
+      // eslint-disable-next-line testing-library/no-node-access
+      document.querySelector('video')
+    ).toBeInTheDocument()
+  })
+})

--- a/components/Media/Media.test.tsx
+++ b/components/Media/Media.test.tsx
@@ -1,0 +1,40 @@
+import {Media} from '@/components/Media/Media'
+import {render, screen} from '@/test-utils'
+
+vi.mock('@/lib/hooks/useMediaType', () => ({
+  useMediaType: () => ({
+    isImage: true,
+    isLink: false,
+    isRedditVideo: false,
+    isYouTube: false,
+    youtubeVideoId: null
+  })
+}))
+
+vi.mock('@/lib/hooks/useMediaAssets', () => ({
+  useMediaAssets: () => ({mediumImage: null, fallbackUrl: null})
+}))
+
+vi.mock('@/lib/store/hooks', () => ({
+  useAppSelector: () => true
+}))
+
+vi.mock('@/lib/utils/getIsVertical', () => ({
+  getIsVertical: () => false
+}))
+
+vi.mock('@/components/ResponsiveImage/ResponsiveImage', () => ({
+  ResponsiveImage: () => <div data-testid="responsive-image" />
+}))
+
+describe('Media', () => {
+  it('renders image when post is an image', () => {
+    const post: any = {
+      title: 'test',
+      url: 'image.jpg',
+      preview: {images: [{source: {width: 1, height: 1}}]}
+    }
+    render(<Media {...post} />)
+    expect(screen.getByTestId('responsive-image')).toBeInTheDocument()
+  })
+})

--- a/components/MediaContainer/MediaContainer.test.tsx
+++ b/components/MediaContainer/MediaContainer.test.tsx
@@ -1,0 +1,13 @@
+import {MediaContainer} from '@/components/MediaContainer/MediaContainer'
+import {render, screen} from '@/test-utils'
+
+describe('MediaContainer', () => {
+  it('renders children', () => {
+    render(
+      <MediaContainer>
+        <p>content</p>
+      </MediaContainer>
+    )
+    expect(screen.getByText('content')).toBeInTheDocument()
+  })
+})

--- a/components/PostCard/PostCard.test.tsx
+++ b/components/PostCard/PostCard.test.tsx
@@ -1,0 +1,33 @@
+import {PostCard} from '@/components/PostCard/PostCard'
+import {render, screen} from '@/test-utils'
+
+vi.mock('@/components/Media/Media', () => ({
+  Media: () => <div data-testid="media" />
+}))
+
+vi.mock('@/lib/utils/formatTimeAgo', () => ({
+  formatTimeAgo: () => 'just now'
+}))
+
+vi.mock('@/lib/utils/getMediumImage', () => ({
+  getMediumImage: () => ({url: 'image.jpg'})
+}))
+
+describe('PostCard', () => {
+  it('renders post information', () => {
+    const post: any = {
+      id: '1',
+      subreddit_name_prefixed: 'r/test',
+      created_utc: 123,
+      permalink: '/r/test/1',
+      title: 'Test post',
+      preview: {images: [{resolutions: []}]},
+      ups: 10,
+      num_comments: 2
+    }
+    render(<PostCard post={post} />)
+    expect(screen.getByRole('heading', {name: 'Test post'})).toBeInTheDocument()
+    expect(screen.getByText(/r\/test/)).toBeInTheDocument()
+    expect(screen.getByText('just now')).toBeInTheDocument()
+  })
+})

--- a/components/Posts/Posts.test.tsx
+++ b/components/Posts/Posts.test.tsx
@@ -1,0 +1,30 @@
+import {Posts} from '@/components/Posts/Posts'
+import {render, screen} from '@/test-utils'
+
+vi.mock('@/lib/hooks/useTrackRecentSubreddit', () => ({
+  useTrackRecentSubreddit: () => {}
+}))
+
+vi.mock('@/lib/hooks/useInfinitePosts', () => ({
+  useInfinitePosts: () => ({
+    data: undefined,
+    error: {message: 'error'},
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isError: true,
+    isFetchingNextPage: false,
+    isLoading: false,
+    noVisiblePosts: false,
+    ref: vi.fn(),
+    wasFiltered: false
+  })
+}))
+
+describe('Posts', () => {
+  it('shows error message when request fails', () => {
+    render(<Posts subreddit="test" />)
+    expect(
+      screen.getByText(/Unable to load posts from Reddit/i)
+    ).toBeInTheDocument()
+  })
+})

--- a/components/ResponsiveImage/ResponsiveImage.test.tsx
+++ b/components/ResponsiveImage/ResponsiveImage.test.tsx
@@ -1,0 +1,20 @@
+import {ResponsiveImage} from '@/components/ResponsiveImage/ResponsiveImage'
+import {render, screen} from '@/test-utils'
+
+vi.mock('@mantine/hooks', () => ({
+  useInViewport: () => ({ref: vi.fn(), inViewport: true})
+}))
+
+vi.mock('@/lib/utils/mediaCache', () => ({
+  getCachedUrl: (url: string) => url
+}))
+
+describe('ResponsiveImage', () => {
+  it('renders image with given src and alt', () => {
+    render(<ResponsiveImage src="img.jpg" alt="desc" />)
+    const link = screen.getByRole('link', {name: 'view full image'})
+    expect(link).toHaveAttribute('href', 'img.jpg')
+    const img = screen.getByAltText('desc')
+    expect(img).toHaveAttribute('loading', 'eager')
+  })
+})

--- a/components/Search/Search.test.tsx
+++ b/components/Search/Search.test.tsx
@@ -1,0 +1,25 @@
+import {Search} from '@/components/Search/Search'
+import {render, screen} from '@/test-utils'
+
+vi.mock('@/lib/hooks/useSubredditSearch', () => ({
+  useSubredditSearch: () => ({
+    query: '',
+    setQuery: vi.fn(),
+    autoCompleteData: [
+      {value: 'reactjs', display_name: 'reactjs', icon_img: ''}
+    ]
+  })
+}))
+
+vi.mock('@/lib/hooks/useHeaderState', () => ({
+  useHeaderState: () => ({showNavbar: false, toggleNavbarHandler: vi.fn()})
+}))
+
+describe('Search', () => {
+  it('renders search input', () => {
+    render(<Search />)
+    expect(
+      screen.getByRole('textbox', {name: /Search subreddits/i})
+    ).toBeInTheDocument()
+  })
+})

--- a/components/Settings/Settings.test.tsx
+++ b/components/Settings/Settings.test.tsx
@@ -1,0 +1,29 @@
+import {Settings} from '@/components/Settings/Settings'
+import {render, screen} from '@/test-utils'
+
+vi.mock('@mantine/notifications', () => ({
+  showNotification: vi.fn()
+}))
+
+vi.mock('@/lib/store/hooks', () => ({
+  useAppDispatch: () => vi.fn(),
+  useAppSelector: () => false
+}))
+
+vi.mock('@mantine/core', async () => {
+  const actual = await vi.importActual<any>('@mantine/core')
+  return {
+    ...actual,
+    useMantineColorScheme: () => ({
+      colorScheme: 'light',
+      setColorScheme: vi.fn()
+    })
+  }
+})
+
+describe('Settings', () => {
+  it('renders settings button', () => {
+    render(<Settings />)
+    expect(screen.getByLabelText('Settings')).toBeInTheDocument()
+  })
+})

--- a/components/Sidebar/Sidebar.test.tsx
+++ b/components/Sidebar/Sidebar.test.tsx
@@ -1,0 +1,34 @@
+import {Sidebar} from '@/components/Sidebar/Sidebar'
+import {render, screen} from '@/test-utils'
+
+vi.mock('@mantine/hooks', async () => {
+  const actual = await vi.importActual<any>('@mantine/hooks')
+  return {
+    ...actual,
+    useMounted: () => true
+  }
+})
+
+vi.mock('@/lib/hooks/useRemoveItemFromHistory', () => ({
+  useRemoveItemFromHistory: () => ({remove: vi.fn()})
+}))
+
+vi.mock('@/lib/store/services/redditApi', async (importOriginal) => {
+  const actual: any = await importOriginal()
+  return {
+    ...actual,
+    useGetPopularSubredditsQuery: () => ({data: []})
+  }
+})
+
+vi.mock('@/lib/hooks/useHeaderState', () => ({
+  useHeaderState: () => ({showNavbar: false, toggleNavbarHandler: vi.fn()})
+}))
+
+describe('Sidebar', () => {
+  it('renders basic links', () => {
+    render(<Sidebar />)
+    expect(screen.getByRole('link', {name: 'All'})).toBeInTheDocument()
+    expect(screen.getByRole('link', {name: 'Popular'})).toBeInTheDocument()
+  })
+})

--- a/components/SubredditName/SubredditName.test.tsx
+++ b/components/SubredditName/SubredditName.test.tsx
@@ -1,0 +1,24 @@
+import {SubredditName} from '@/components/SubredditName/SubredditName'
+import {render, screen} from '@/test-utils'
+import userEvent from '@testing-library/user-event'
+
+vi.mock('next/image', () => ({
+  // eslint-disable-next-line jsx-a11y/alt-text
+  default: (props: any) => <img {...props} />
+}))
+
+vi.mock('@/components/Favorite/Favorite', () => ({
+  Favorite: () => <div data-testid="favorite" />
+}))
+
+describe('SubredditName', () => {
+  it('renders name and handles delete', async () => {
+    const onDelete = vi.fn()
+    render(<SubredditName name="test" onDelete={onDelete} enableFavorite />)
+    expect(screen.getByText('r/test')).toBeInTheDocument()
+    expect(screen.getByTestId('favorite')).toBeInTheDocument()
+    const btn = screen.getByRole('button', {name: 'Clear subreddit'})
+    await userEvent.click(btn)
+    expect(onDelete).toHaveBeenCalled()
+  })
+})

--- a/components/YouTubePlayer/YouTubePlayer.test.tsx
+++ b/components/YouTubePlayer/YouTubePlayer.test.tsx
@@ -1,0 +1,15 @@
+import {YouTubePlayer} from '@/components/YouTubePlayer/YouTubePlayer'
+import {render, screen} from '@/test-utils'
+
+vi.mock('@mantine/hooks', () => ({
+  useInViewport: () => ({ref: vi.fn(), inViewport: true})
+}))
+
+describe('YouTubePlayer', () => {
+  it('renders thumbnail button when in viewport', () => {
+    render(<YouTubePlayer videoId="abc" />)
+    expect(
+      screen.getByRole('button', {name: 'Play YouTube video'})
+    ).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for Favorite component
- test Posts error handling and Sidebar links
- cover remaining UI components

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68bc8c9f302883209293188acefa37be