### PR TITLE
test: avoid direct DOM access in HlsPlayer

### DIFF
--- a/components/HlsPlayer/HlsPlayer.test.tsx
+++ b/components/HlsPlayer/HlsPlayer.test.tsx
@@ -1,5 +1,5 @@
 import {HlsPlayer} from '@/components/HlsPlayer/HlsPlayer'
-import {render} from '@/test-utils'
+import {render, screen} from '@/test-utils'
 
 const videoRef = {current: null}
 vi.mock('@/lib/hooks/useHlsVideo', () => ({
@@ -18,9 +18,6 @@ describe('HlsPlayer', () => {
       />
     )
 
-    expect(
-      // eslint-disable-next-line testing-library/no-node-access
-      document.querySelector('video')
-    ).toBeInTheDocument()
+    expect(screen.getByTestId('video')).toBeInTheDocument()
   })
 })

--- a/components/HlsPlayer/HlsPlayer.tsx
+++ b/components/HlsPlayer/HlsPlayer.tsx
@@ -32,6 +32,7 @@ export function HlsPlayer({
 
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <video
+        data-testid="video"
         autoPlay={autoPlay}
         controls={controls}
         data-hint={dataHint}


### PR DESCRIPTION
## Summary
- add test id to HlsPlayer video element
- use `screen.getByTestId` instead of `document.querySelector`

## Testing
- `npm test components/HlsPlayer/HlsPlayer.test.tsx`
- `npm run lint components/HlsPlayer/HlsPlayer.tsx components/HlsPlayer/HlsPlayer.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bda582242c8320826518c1a8a30b95