### PR TITLE
fix: mock next image in tests

### DIFF
--- a/components/SubredditName/SubredditName.test.tsx
+++ b/components/SubredditName/SubredditName.test.tsx
@@ -2,11 +2,6 @@ import {SubredditName} from '@/components/SubredditName/SubredditName'
 import {render, screen} from '@/test-utils'
 import userEvent from '@testing-library/user-event'
 
-vi.mock('next/image', () => ({
-  // eslint-disable-next-line jsx-a11y/alt-text
-  default: (props: any) => <img {...props} />
-}))
-
 vi.mock('@/components/Favorite/Favorite', () => ({
   Favorite: () => <div data-testid="favorite" />
 }))

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
         '**/*.spec.{ts,tsx}',
         '**/*.test.{ts,tsx}',
         '**/test-utils/**',
+        '**/app/**/*.{ts,tsx}',
         '**/types/**',
         '*.config.ts',
         '*.d.ts'

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,8 +1,17 @@
 import {setupBrowserMocks} from '@/test-utils/mocks/browserMocks'
 import {server} from '@/test-utils/msw/server'
 import '@testing-library/jest-dom'
+import React from 'react'
 import {URLSearchParams as NodeURLSearchParams} from 'url'
-import {afterAll, afterEach, beforeAll} from 'vitest'
+import {afterAll, afterEach, beforeAll, vi} from 'vitest'
+
+vi.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    const {unoptimized, priority, ...rest} = props
+    return React.createElement('img', rest)
+  }
+}))
 
 // Polyfill: Vitest does not provide URLSearchParams in Node by default
 // https://github.com/vitest-dev/vitest/issues/7906


### PR DESCRIPTION
## Summary
- globally mock `next/image` to remove unsupported props in tests
- rely on shared mock in `SubredditName` tests
- exclude Next.js `app` directory from coverage

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bda790854c8320ae2176f40693a1c9