### PR TITLE
Potential fix for code scanning alert no. 7: Server-side request forgery

### DIFF
--- a/app/api/reddit/route.ts
+++ b/app/api/reddit/route.ts
@@ -42,7 +42,7 @@ function validateOrigin(request: NextRequest): boolean {
 
 /**
  * Validates that the provided path is a safe and legal Reddit API path.
- * @param {string} path 
+ * @param path The path to validate.
  * @returns {boolean}
  */
 function isSafeRedditPath(path: string): boolean {

--- a/app/api/reddit/route.ts
+++ b/app/api/reddit/route.ts
@@ -56,7 +56,7 @@ function isSafeRedditPath(path: string): boolean {
   if (path.includes('#')) return false;
   // Optionally allow-list known prefixes (e.g. /r/, /user/, /api/, /subreddits/, etc.)
   // Example:
-  //    if (!/^\/(r|user|subreddits|api|comments|by_id|message|live|prefs|api|search|mod)/.test(path)) return false;
+  //    if (!/^\/(r|user|subreddits|api|comments|by_id|message|live|prefs|search|mod)/.test(path)) return false;
   return true;
 }
 

--- a/app/api/reddit/route.ts
+++ b/app/api/reddit/route.ts
@@ -41,6 +41,26 @@ function validateOrigin(request: NextRequest): boolean {
 }
 
 /**
+ * Validates that the provided path is a safe and legal Reddit API path.
+ * @param {string} path 
+ * @returns {boolean}
+ */
+function isSafeRedditPath(path: string): boolean {
+  // Must start with exactly one /
+  if (!path || !path.startsWith('/') || path.startsWith('//')) return false;
+  // Disallow path traversal
+  if (path.includes('..')) return false;
+  // Disallow protocol-relative, or absolute URLs
+  if (path.startsWith('http:') || path.startsWith('https:')) return false;
+  // Disallow fragments or dangerous characters
+  if (path.includes('#')) return false;
+  // Optionally allow-list known prefixes (e.g. /r/, /user/, /api/, /subreddits/, etc.)
+  // Example:
+  //    if (!/^\/(r|user|subreddits|api|comments|by_id|message|live|prefs|api|search|mod)/.test(path)) return false;
+  return true;
+}
+
+/**
  * Reddit API Proxy Route Handler.
  *
  * @example
@@ -68,6 +88,21 @@ export async function GET(request: NextRequest) {
     })
     return NextResponse.json(
       {error: 'Path parameter is required'},
+      {status: 400}
+    )
+  }
+
+  // Validate path to prevent SSRF and abuse
+  if (!isSafeRedditPath(path)) {
+    logError('Invalid or dangerous Reddit API path', {
+      component: 'redditApiRoute',
+      action: 'validatePath',
+      path,
+      url: request.url,
+      searchParams: Object.fromEntries(searchParams.entries())
+    })
+    return NextResponse.json(
+      {error: 'Invalid path parameter'},
       {status: 400}
     )
   }


### PR DESCRIPTION
Potential fix for [https://github.com/gregrickaby/viewer-for-reddit/security/code-scanning/7](https://github.com/gregrickaby/viewer-for-reddit/security/code-scanning/7)

The best way to fix the problem is to strictly validate and constrain the `path` value provided by the user. Rather than allowing any arbitrary string, only permit paths that conform to Reddit API's documented endpoints. This can be enforced by:

- Ensuring the path starts with a single `/`, not `//` (to avoid protocol-relative URLs).
- Preventing path traversal by disallowing `../` or similar patterns.
- Optionally, maintain an allow-list of acceptable base paths or regular expressions that match known-good Reddit API resources.
- Stripping or rejecting any attempts to include protocol, domain, or query starting with `http`, `//`, or `\`.

These changes should be implemented in the file `app/api/reddit/route.ts` around where the `path` parameter is extracted and used (lines 59-93):

- Add a new function to validate/sanitize the `path`.
- Use the validated path in the `fetch` call, rejecting invalid values with 400 Bad Request error.

No external dependencies are needed; this can be implemented with basic string and regex operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
