### PR TITLE
feat: implement single post display with proper routing and comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 npm run lint        # ESLint with Mantine config - must pass
 npm run typecheck   # TypeScript strict checking - must pass
 npm run test        # Vitest unit tests - must pass
+npm run dev         # Start dev server. Review changes using Playwright MCP
 ```
 
 **Critical**: Run these commands in sequence for any code changes. Stop if any step fails.
@@ -48,7 +49,7 @@ npm run typegen:validate  # Validate OpenAPI specification
 ### Tech Stack
 
 - **Framework**: Next.js 15+ (App Router)
-- **UI**: Mantine v8 component library
+- **UI**: Mantine v8 component library. Documentation URL: <https://mantine.dev/llms.txt>
 - **State Management**: Redux Toolkit + RTK Query
 - **Authentication**: Reddit OAuth 2.0 (Server Actions)
 - **Testing**: Vitest + React Testing Library + MSW v2
@@ -156,6 +157,10 @@ npm run test
 
 # 3. For UI changes, also run:
 npm run test:e2e
+
+# 4. For feature completion, run dev server and validate with Playwright:
+npm run dev               # Start development server
+# Use Playwright MCP to validate feature works as expected
 ```
 
 > **Note**: This matches the validation gate in copilot-instructions.md for consistency across all AI agents.
@@ -224,3 +229,13 @@ Reference timeouts from copilot-instructions.md:
 - **Type generation**: 60s
 - **Test suite**: 120s
 - **Lint**: 30s
+
+## Code Quality Standards
+
+### Comment Guidelines
+
+- Do NOT insert superfluous comments or explanatory comments
+- Do NOT leave comments explaining why you changed something from a previous edit
+- Only add comments when documenting complex business logic or non-obvious Next.js patterns
+- Let code be self-documenting through clear naming and structure
+- Focus on code clarity over comment density

--- a/app/(default)/r/[subreddit]/comments/[postId]/page.tsx
+++ b/app/(default)/r/[subreddit]/comments/[postId]/page.tsx
@@ -1,0 +1,56 @@
+import {SinglePost} from '@/components/SinglePost/SinglePost'
+import type {Metadata} from 'next'
+
+export interface SinglePostPageProps {
+  params: Promise<{
+    subreddit: string
+    postId: string
+  }>
+}
+
+/**
+ * Generate metadata for the single post page.
+ */
+export async function generateMetadata({
+  params
+}: SinglePostPageProps): Promise<Metadata> {
+  const {subreddit, postId} = await params
+
+  return {
+    title: `Post in r/${subreddit} - Reddit Viewer`,
+    description: `View post ${postId} in r/${subreddit} subreddit`,
+    openGraph: {
+      title: `Post in r/${subreddit}`,
+      description: `View post ${postId} in r/${subreddit} subreddit`,
+      type: 'article'
+    },
+    twitter: {
+      card: 'summary',
+      title: `Post in r/${subreddit}`,
+      description: `View post ${postId} in r/${subreddit} subreddit`
+    }
+  }
+}
+
+/**
+ * Single Post Page - displays a Reddit post with its comments
+ *
+ * This page component handles the route /r/[subreddit]/comments/[postId]
+ * and renders a complete view of a single Reddit post including its comments.
+ *
+ * Route examples:
+ * - /r/programming/comments/abc123
+ * - /r/javascript/comments/xyz789
+ *
+ * @param params - Route parameters containing subreddit and postId
+ * @returns Single post page with post content and comments
+ */
+export default async function SinglePostPage({params}: SinglePostPageProps) {
+  const {subreddit, postId} = await params
+
+  return (
+    <main>
+      <SinglePost subreddit={subreddit} postId={postId} />
+    </main>
+  )
+}

--- a/app/(default)/r/[subreddit]/page.tsx
+++ b/app/(default)/r/[subreddit]/page.tsx
@@ -9,18 +9,18 @@ import type {Params, SearchParams, SortingOption} from '@/lib/types'
  */
 export async function generateMetadata(props: {params: Params}) {
   const params = await props.params
-  const slug = params.slug
+  const subreddit = params.subreddit
 
   return {
-    title: `/r/${slug} - ${config.siteName}`,
-    description: `Browse posts in /r/${slug} anonymously with Viewer for Reddit.`,
+    title: `/r/${subreddit} - ${config.siteName}`,
+    description: `Browse posts in /r/${subreddit} anonymously with Viewer for Reddit.`,
     alternates: {
-      canonical: `${config.siteUrl}r/${slug}`
+      canonical: `${config.siteUrl}r/${subreddit}`
     },
     openGraph: {
-      title: `/r/${slug} - ${config.siteName}`,
-      description: `Posts in /r/${slug}, updated in real time.`,
-      url: `${config.siteUrl}r/${slug}`,
+      title: `/r/${subreddit} - ${config.siteName}`,
+      description: `Posts in /r/${subreddit}, updated in real time.`,
+      url: `${config.siteUrl}r/${subreddit}`,
       images: [
         {
           url: `${config.siteUrl}social-share.webp`,
@@ -41,13 +41,13 @@ export default async function Page(props: {
   searchParams: SearchParams
 }) {
   const params = await props.params
-  const slug = params.slug
+  const subreddit = params.subreddit
   const searchParams = await props.searchParams
   const sort = searchParams.sort as SortingOption
 
   return (
     <>
-      <Posts subreddit={slug} sort={sort} />
+      <Posts subreddit={subreddit} sort={sort} />
       <BossButton />
       <BackToTop />
     </>

--- a/components/Comments/Comments.tsx
+++ b/components/Comments/Comments.tsx
@@ -23,17 +23,32 @@ interface CommentsProps {
   permalink: string
   postLink: string
   open: boolean
+  comments?: AutoCommentData[]
 }
 
-export function Comments({permalink, postLink, open}: Readonly<CommentsProps>) {
-  const [fetchComments, {data: comments, isLoading}] =
+export function Comments({
+  permalink,
+  postLink,
+  open,
+  comments: providedComments
+}: Readonly<CommentsProps>) {
+  const [fetchComments, {data: fetchedComments, isLoading}] =
     useLazyGetPostCommentsQuery()
 
+  const comments = providedComments || fetchedComments
+
   useEffect(() => {
-    if (open && !comments && !isLoading) {
+    if (open && !providedComments && !fetchedComments && !isLoading) {
       void fetchComments(permalink)
     }
-  }, [open, comments, isLoading, fetchComments, permalink])
+  }, [
+    open,
+    providedComments,
+    fetchedComments,
+    isLoading,
+    fetchComments,
+    permalink
+  ])
 
   if (isLoading) {
     return (

--- a/components/PostCard/PostCard.test.tsx
+++ b/components/PostCard/PostCard.test.tsx
@@ -57,4 +57,42 @@ describe('PostCard', () => {
     expect(time).toBeInTheDocument()
     expect(time).toHaveAttribute('dateTime', '')
   })
+
+  it('should use internal routing by default', () => {
+    const post: any = {
+      id: 'abc123',
+      subreddit_name_prefixed: 'r/programming',
+      permalink: '/r/programming/comments/abc123/title/',
+      title: 'Test post',
+      preview: {images: [{resolutions: []}]},
+      ups: 10,
+      num_comments: 2
+    }
+
+    render(<PostCard post={post} />)
+
+    const titleLink = screen.getByRole('heading', {level: 2}).closest('a')
+    expect(titleLink).toHaveAttribute('href', '/r/programming/comments/abc123')
+  })
+
+  it('should use external Reddit links when useInternalRouting is false', () => {
+    const post: any = {
+      id: 'abc123',
+      subreddit_name_prefixed: 'r/programming',
+      permalink: '/r/programming/comments/abc123/title/',
+      title: 'Test post',
+      preview: {images: [{resolutions: []}]},
+      ups: 10,
+      num_comments: 2
+    }
+
+    render(<PostCard post={post} useInternalRouting={false} />)
+
+    const titleLink = screen.getByRole('heading', {level: 2}).closest('a')
+    expect(titleLink).toHaveAttribute(
+      'href',
+      'https://reddit.com/r/programming/comments/abc123/title/'
+    )
+    expect(titleLink).toHaveAttribute('target', '_blank')
+  })
 })

--- a/components/SinglePost/SinglePost.module.css
+++ b/components/SinglePost/SinglePost.module.css
@@ -1,0 +1,82 @@
+/* SinglePost component styles */
+
+.backLink {
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.backLink:hover {
+  color: var(--mantine-color-blue-7);
+}
+
+.commentCard {
+  border-left: 3px solid var(--mantine-color-blue-5);
+  transition: border-color 0.2s ease;
+}
+
+.commentCard:hover {
+  border-left-color: var(--mantine-color-blue-7);
+}
+
+.commentAuthor {
+  font-weight: 600;
+  color: var(--mantine-color-dimmed);
+}
+
+.commentScore {
+  font-size: var(--mantine-font-size-xs);
+  color: var(--mantine-color-dimmed);
+}
+
+.commentBody {
+  line-height: 1.5;
+}
+
+/* Ensure HTML content in comments is properly styled */
+.commentBody :global(p) {
+  margin: 0 0 0.5rem 0;
+}
+
+.commentBody :global(p:last-child) {
+  margin-bottom: 0;
+}
+
+.commentBody :global(a) {
+  color: var(--mantine-color-blue-6);
+  text-decoration: none;
+}
+
+.commentBody :global(a:hover) {
+  text-decoration: underline;
+}
+
+.commentBody :global(strong) {
+  font-weight: 600;
+}
+
+.commentBody :global(em) {
+  font-style: italic;
+}
+
+.commentBody :global(code) {
+  background: var(--mantine-color-gray-1);
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+  font-family: var(--mantine-font-family-monospace);
+  font-size: 0.9em;
+}
+
+.commentBody :global(pre) {
+  background: var(--mantine-color-gray-1);
+  padding: 0.5rem;
+  border-radius: 6px;
+  overflow-x: auto;
+  font-family: var(--mantine-font-family-monospace);
+}
+
+.commentBody :global(blockquote) {
+  border-left: 4px solid var(--mantine-color-gray-4);
+  padding-left: 1rem;
+  margin: 0.5rem 0;
+  color: var(--mantine-color-dimmed);
+}

--- a/components/SinglePost/SinglePost.test.tsx
+++ b/components/SinglePost/SinglePost.test.tsx
@@ -1,0 +1,157 @@
+import {SinglePost} from '@/components/SinglePost/SinglePost'
+import {render, screen, waitFor} from '@/test-utils'
+
+describe('SinglePost', () => {
+  const defaultProps = {
+    subreddit: 'programming',
+    postId: 'abc123'
+  }
+
+  it('should render loading state initially', () => {
+    render(<SinglePost {...defaultProps} />)
+
+    expect(screen.getByText('Loading post...')).toBeInTheDocument()
+    // Mantine Loader component is rendered as a span, not with progressbar role
+    expect(document.querySelector('.mantine-Loader-root')).toBeInTheDocument()
+  })
+
+  it('should render post and comments successfully', async () => {
+    render(<SinglePost {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading post...')).not.toBeInTheDocument()
+    })
+
+    // Check for back navigation link
+    expect(screen.getByText('Back to r/programming')).toBeInTheDocument()
+
+    // Check for comments section (might be empty initially)
+    expect(screen.getByText(/Comments/)).toBeInTheDocument()
+  })
+
+  it('should render post with no comments', async () => {
+    render(<SinglePost subreddit="programming" postId="nocomments" />)
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading post...')).not.toBeInTheDocument()
+    })
+
+    // Should show comments section
+    expect(screen.getByText(/Comments/)).toBeInTheDocument()
+  })
+
+  it('should render 404 error state', async () => {
+    render(<SinglePost subreddit="notfound" postId="abc123" />)
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading post...')).not.toBeInTheDocument()
+    })
+
+    // Should show error message
+    expect(screen.getByText('Post not found')).toBeInTheDocument()
+    expect(screen.getByText('Back to r/notfound')).toBeInTheDocument()
+  })
+
+  it('should render 403 error state for private subreddit', async () => {
+    render(<SinglePost subreddit="private" postId="abc123" />)
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading post...')).not.toBeInTheDocument()
+    })
+
+    // Should show private subreddit error
+    expect(
+      screen.getByText('This subreddit is private or restricted')
+    ).toBeInTheDocument()
+  })
+
+  it('should handle generic error state', async () => {
+    // Test with invalid subreddit to trigger generic error
+    render(<SinglePost subreddit="error" postId="abc123" />)
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading post...')).not.toBeInTheDocument()
+    })
+
+    // Should show generic error message
+    expect(screen.getByText('Failed to load post')).toBeInTheDocument()
+  })
+
+  it('should render back navigation links correctly', async () => {
+    render(<SinglePost {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading post...')).not.toBeInTheDocument()
+    })
+
+    const backLinks = screen.getAllByText('Back to r/programming')
+    expect(backLinks).toHaveLength(1)
+
+    // Check that the link has correct href
+    const backLink = backLinks[0].closest('a')
+    expect(backLink).toHaveAttribute('href', '/r/programming')
+  })
+
+  it('should render comment scores correctly', async () => {
+    render(<SinglePost {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading post...')).not.toBeInTheDocument()
+    })
+
+    // Check for comment scores
+    expect(screen.getByText('25 points')).toBeInTheDocument()
+    expect(screen.getByText('15 points')).toBeInTheDocument()
+  })
+
+  it('should handle HTML content in comments safely', async () => {
+    render(<SinglePost {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading post...')).not.toBeInTheDocument()
+    })
+
+    // Comments should render with HTML content
+    const commentElements = screen.getAllByText(
+      /Great post|Not another JavaScript/
+    )
+    expect(commentElements).toHaveLength(2)
+  })
+
+  it('should not show inline comments toggle in SinglePost view', async () => {
+    render(<SinglePost {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading post...')).not.toBeInTheDocument()
+    })
+
+    // The PostCard should not have the comments toggle since useInternalRouting=false
+    // and we're already viewing the single post page
+    const commentToggleButtons = screen.queryAllByRole('button', {
+      name: /comments/
+    })
+
+    // Should only find the comment buttons in the actual comments section, not in PostCard
+    commentToggleButtons.forEach((button) => {
+      // If there are any comment buttons, they should not be for showing/hiding comments
+      expect(button.getAttribute('aria-expanded')).toBeFalsy()
+    })
+  })
+
+  it('should have proper accessibility attributes', async () => {
+    render(<SinglePost {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading post...')).not.toBeInTheDocument()
+    })
+
+    // Check for proper main content structure
+    const main = screen.getByRole('main')
+    expect(main).toBeInTheDocument()
+
+    // Check for heading structure
+    const commentsHeading = screen.getByRole('heading', {name: /Comments/})
+    expect(commentsHeading).toBeInTheDocument()
+    expect(commentsHeading).toHaveAttribute('aria-level', '3')
+  })
+})

--- a/components/SinglePost/SinglePost.tsx
+++ b/components/SinglePost/SinglePost.tsx
@@ -1,0 +1,165 @@
+'use client'
+
+import {Comments} from '@/components/Comments/Comments'
+import {PostCard} from '@/components/PostCard/PostCard'
+import {useGetSinglePostQuery} from '@/lib/store/services/redditApi'
+import {
+  Alert,
+  Card,
+  Container,
+  Group,
+  Loader,
+  Stack,
+  Text,
+  Title
+} from '@mantine/core'
+import Link from 'next/link'
+import {IoAlert, IoArrowBack} from 'react-icons/io5'
+import classes from './SinglePost.module.css'
+
+export interface SinglePostProps {
+  readonly subreddit: string
+  readonly postId: string
+}
+
+/**
+ * SinglePost component displays a complete view of a Reddit post with comments.
+ *
+ * Features:
+ * - Fetches post and comments data in a single request
+ * - Displays loading states and error handling
+ * - Shows post content using existing PostCard component
+ * - Renders comments list with proper formatting
+ * - Includes navigation back to subreddit
+ * - Handles edge cases like missing posts or private subreddits
+ *
+ * @param subreddit - The subreddit name (e.g., "programming")
+ * @param postId - The Reddit post ID (e.g., "abc123")
+ * @returns JSX.Element for the complete single post view
+ */
+export function SinglePost({subreddit, postId}: Readonly<SinglePostProps>) {
+  const {data, isLoading, isError, error} = useGetSinglePostQuery({
+    subreddit,
+    postId
+  })
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <Container size="md">
+        <Stack align="center" gap="md" py="xl">
+          <Loader size="lg" />
+          <Text c="dimmed">Loading post...</Text>
+        </Stack>
+      </Container>
+    )
+  }
+
+  // Error state
+  if (isError) {
+    const errorMessage =
+      error &&
+      typeof error === 'object' &&
+      'status' in error &&
+      error.status === 404
+        ? 'Post not found'
+        : error &&
+            typeof error === 'object' &&
+            'status' in error &&
+            error.status === 403
+          ? 'This subreddit is private or restricted'
+          : 'Failed to load post'
+
+    return (
+      <Container size="md">
+        <Stack gap="md" py="md">
+          <Group>
+            <Link href={`/r/${subreddit}`}>
+              <Group gap="xs" c="blue">
+                <IoArrowBack />
+                <Text size="sm">Back to r/{subreddit}</Text>
+              </Group>
+            </Link>
+          </Group>
+
+          <Alert
+            icon={<IoAlert size={16} />}
+            title="Error"
+            color="red"
+            variant="light"
+          >
+            {errorMessage}. Please try again or{' '}
+            <Link href={`/r/${subreddit}`}>return to r/{subreddit}</Link>.
+          </Alert>
+        </Stack>
+      </Container>
+    )
+  }
+
+  // Success state with data
+  if (!data) {
+    return (
+      <Container size="md">
+        <Alert
+          icon={<IoAlert size={16} />}
+          title="No Data"
+          color="orange"
+          variant="light"
+        >
+          No post data available.
+        </Alert>
+      </Container>
+    )
+  }
+
+  const {post, comments} = data
+
+  return (
+    <Container size="md">
+      <Stack gap="md" py="md">
+        {/* Navigation back to subreddit */}
+        <Group>
+          <Link href={`/r/${subreddit}`} className={classes.backLink}>
+            <Group gap="xs" c="blue">
+              <IoArrowBack />
+              <Text size="sm">Back to r/{subreddit}</Text>
+            </Group>
+          </Link>
+        </Group>
+
+        {/* Post content */}
+        <PostCard post={post} useInternalRouting={false} />
+
+        {/* Comments section */}
+        <Card padding="md" radius="md" shadow="sm" withBorder>
+          <Stack gap="md">
+            <Title order={3} size="lg">
+              Comments ({comments.length})
+            </Title>
+
+            {comments.length === 0 ? (
+              <Text c="dimmed" ta="center" py="xl">
+                No comments yet. Be the first to comment on{' '}
+                <Link
+                  href={`https://reddit.com${post.permalink}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Reddit
+                </Link>
+                !
+              </Text>
+            ) : (
+              <Comments
+                permalink={post.permalink || ''}
+                postLink={`https://reddit.com${post.permalink || ''}`}
+                open
+                comments={comments}
+              />
+            )}
+          </Stack>
+        </Card>
+      </Stack>
+    </Container>
+  )
+}

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -14,7 +14,7 @@ export type DeepPartial<T> = {
 /**
  * Next.js dynamic route parameters.
  */
-export type Params = Promise<{slug: string}>
+export type Params = Promise<{subreddit: string}>
 export type UserParams = Promise<{username: string}>
 export type SearchParams = Promise<{
   [key: string]: string | string[] | undefined

--- a/test-utils/mocks/singlePost.ts
+++ b/test-utils/mocks/singlePost.ts
@@ -1,0 +1,197 @@
+import type {DeepPartial} from '@/lib/types'
+
+/**
+ * Mock data for a single Reddit post with comments response.
+ * Mirrors the structure returned by Reddit's /r/subreddit/comments/postId.json endpoint.
+ * Returns an array with [postListing, commentsListing] as per Reddit API format.
+ */
+export const singlePostMock: DeepPartial<
+  [Record<string, any>, Record<string, any>]
+> = [
+  // Post listing (first element)
+  {
+    kind: 'Listing',
+    data: {
+      after: null,
+      dist: 1,
+      modhash: '',
+      geo_filter: null,
+      children: [
+        {
+          kind: 't3',
+          data: {
+            id: 'abc123',
+            subreddit: 'programming',
+            subreddit_name_prefixed: 'r/programming',
+            title:
+              'Amazing new JavaScript framework that will change everything',
+            author: 'testuser',
+            created_utc: 1677695999,
+            ups: 1337,
+            num_comments: 42,
+            permalink:
+              '/r/programming/comments/abc123/amazing_new_javascript_framework/',
+            url: 'https://example.com/article',
+            selftext:
+              'This is the post content with some **markdown** formatting.',
+            selftext_html:
+              '&lt;div class="md"&gt;&lt;p&gt;This is the post content with some &lt;strong&gt;markdown&lt;/strong&gt; formatting.&lt;/p&gt;&lt;/div&gt;',
+            thumbnail: '',
+            thumbnail_height: null,
+            thumbnail_width: null,
+            is_self: true,
+            is_video: false,
+            stickied: false,
+            locked: false,
+            archived: false,
+            over_18: false,
+            spoiler: false,
+            hidden: false,
+            saved: false,
+            clicked: false,
+            visited: false,
+            score: 1337,
+            upvote_ratio: 0.95,
+            quarantine: false,
+            gilded: 0,
+            distinguished: null,
+            media: null,
+            secure_media: null,
+            media_embed: {},
+            secure_media_embed: {},
+            post_hint: undefined,
+            preview: undefined
+          }
+        }
+      ]
+    }
+  },
+  // Comments listing (second element)
+  {
+    kind: 'Listing',
+    data: {
+      after: null,
+      dist: 3,
+      modhash: '',
+      geo_filter: null,
+      children: [
+        {
+          kind: 't1',
+          data: {
+            id: 'comment1',
+            author: 'commentuser1',
+            body: 'Great post! This framework looks really promising.',
+            body_html:
+              '&lt;div class="md"&gt;&lt;p&gt;Great post! This framework looks really promising.&lt;/p&gt;&lt;/div&gt;',
+            created_utc: 1677696100,
+            score: 25,
+            ups: 25,
+            downs: 0,
+            permalink:
+              '/r/programming/comments/abc123/amazing_new_javascript_framework/comment1/',
+            parent_id: 't3_abc123',
+            depth: 0,
+            replies: '',
+            distinguished: null,
+            stickied: false,
+            is_submitter: false,
+            collapsed: false,
+            score_hidden: false,
+            archived: false,
+            locked: false,
+            gilded: 0,
+            saved: false,
+            controversiality: 0
+          }
+        },
+        {
+          kind: 't1',
+          data: {
+            id: 'comment2',
+            author: 'commentuser2',
+            body: 'Not another JavaScript framework... 😩',
+            body_html:
+              '&lt;div class="md"&gt;&lt;p&gt;Not another JavaScript framework... 😩&lt;/p&gt;&lt;/div&gt;',
+            created_utc: 1677696200,
+            score: 15,
+            ups: 18,
+            downs: 3,
+            permalink:
+              '/r/programming/comments/abc123/amazing_new_javascript_framework/comment2/',
+            parent_id: 't3_abc123',
+            depth: 0,
+            replies: '',
+            distinguished: null,
+            stickied: false,
+            is_submitter: false,
+            collapsed: false,
+            score_hidden: false,
+            archived: false,
+            locked: false,
+            gilded: 0,
+            saved: false,
+            controversiality: 1
+          }
+        },
+        {
+          kind: 't1',
+          data: {
+            id: 'comment3',
+            author: 'AutoModerator',
+            body: 'This is an AutoModerator comment that should be filtered out.',
+            body_html:
+              '&lt;div class="md"&gt;&lt;p&gt;This is an AutoModerator comment that should be filtered out.&lt;/p&gt;&lt;/div&gt;',
+            created_utc: 1677696050,
+            score: 1,
+            ups: 1,
+            downs: 0,
+            permalink:
+              '/r/programming/comments/abc123/amazing_new_javascript_framework/comment3/',
+            parent_id: 't3_abc123',
+            depth: 0,
+            replies: '',
+            distinguished: 'moderator',
+            stickied: true,
+            is_submitter: false,
+            collapsed: false,
+            score_hidden: false,
+            archived: false,
+            locked: false,
+            gilded: 0,
+            saved: false,
+            controversiality: 0
+          }
+        }
+      ]
+    }
+  }
+]
+
+/**
+ * Mock data for a single post that doesn't exist (404 case)
+ */
+export const singlePostNotFoundMock = {
+  error: 404,
+  message: 'Not Found'
+}
+
+/**
+ * Mock data for a single post with no comments
+ */
+export const singlePostNoCommentsMock: DeepPartial<
+  [Record<string, any>, Record<string, any>]
+> = [
+  // Post listing (same as above)
+  singlePostMock[0],
+  // Empty comments listing
+  {
+    kind: 'Listing',
+    data: {
+      after: null,
+      dist: 0,
+      modhash: '',
+      geo_filter: null,
+      children: []
+    }
+  }
+]

--- a/test-utils/msw/handlers/proxyHandlers.ts
+++ b/test-utils/msw/handlers/proxyHandlers.ts
@@ -75,11 +75,30 @@ function handleUserComments(path: string): Response | null {
  */
 async function handlePostComments(path: string): Promise<Response | null> {
   // Post comments (from subreddit permalink with .json)
-  const postCommentsRegex = /^\/r\/.+\/comments\/[^/]+(?:\/[^/]*)?\.json$/
+  const postCommentsRegex = /^\/r\/(.+)\/comments\/([^/]+)(?:\/[^/]*)?\.json$/
   const pathWithoutQuery = path.split('?')[0]
-  if (postCommentsRegex.test(pathWithoutQuery)) {
-    const {postCommentsMock} = await import('../../mocks/postComments')
-    return HttpResponse.json(postCommentsMock)
+  const match = postCommentsRegex.exec(pathWithoutQuery)
+
+  if (match) {
+    const [, subreddit, postId] = match
+
+    // Handle test cases for single post endpoint
+    if (subreddit === 'notfound' || postId === 'notfound') {
+      return new HttpResponse(null, {status: 404})
+    }
+
+    if (subreddit === 'private') {
+      return new HttpResponse(null, {status: 403})
+    }
+
+    if (postId === 'nocomments') {
+      const {singlePostNoCommentsMock} = await import('../../mocks/singlePost')
+      return HttpResponse.json(singlePostNoCommentsMock)
+    }
+
+    // Use the new single post mock for better test data
+    const {singlePostMock} = await import('../../mocks/singlePost')
+    return HttpResponse.json(singlePostMock)
   }
 
   // Post comments (general pattern for comments pages)


### PR DESCRIPTION
## Summary
- Fix PostCard component to support internal app routing vs external Reddit links
- Add `useInternalRouting` prop with intelligent permalink parsing  
- Replace custom comment rendering with existing Comments component
- Ensure proper HTML sanitization and styling for comments
- Add comprehensive tests for routing functionality
- Update CLAUDE.md with GitHub workflow including format step

## Test Plan
- [x] Single post pages load without 404 errors
- [x] Comments display with proper formatting and styling  
- [x] PostCard supports both internal and external routing modes
- [x] All tests pass and code quality gates satisfied
- [x] Playwright validation confirms functionality works end-to-end

## Technical Details
- **Before**: PostCard linked to Reddit permalinks causing 404s
- **After**: Smart URL parsing converts `/r/subreddit/comments/postId/title/` → `/r/subreddit/comments/postId`
- **Comments**: Now uses existing Comments component with proper sanitization instead of raw HTML
- **Testing**: Added comprehensive test coverage for new routing functionality

## Screenshots
Single post page now displays properly with formatted comments, timestamps, upvote counts, and "View on Reddit" links.

Fixes #621

🤖 Generated with [Claude Code](https://claude.com/claude-code)